### PR TITLE
feat: add Activity Heatmap Calendar page

### DIFF
--- a/actions/activity.ts
+++ b/actions/activity.ts
@@ -1,0 +1,29 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+
+import prisma from '@/lib/prisma'
+
+/**
+ * Record today's activity. If an entry already exists for today, increment count.
+ * @param note - Optional memo describing what was done.
+ */
+export async function recordActivity(note: string = '') {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  await prisma.activityLog.upsert({
+    where: { date: today },
+    update: {
+      count: { increment: 1 },
+      note,
+    },
+    create: {
+      date: today,
+      count: 1,
+      note,
+    },
+  })
+
+  revalidatePath('/activity')
+}

--- a/app/activity/page.tsx
+++ b/app/activity/page.tsx
@@ -2,6 +2,7 @@ import { ArrowLeftIcon } from 'lucide-react'
 import Link from 'next/link'
 
 import { HeatmapCalendar } from '@/components/heatmap-calendar'
+import { toLocalDateString } from '@/lib/date'
 import { Main } from '@/components/main'
 import prisma from '@/lib/prisma'
 
@@ -18,7 +19,7 @@ export default async function Page() {
   })
 
   const data = logs.map((log) => ({
-    date: log.date.toISOString().split('T')[0],
+    date: toLocalDateString(log.date),
     count: log.count,
     note: log.note,
   }))

--- a/app/activity/page.tsx
+++ b/app/activity/page.tsx
@@ -1,0 +1,41 @@
+import { ArrowLeftIcon } from 'lucide-react'
+import Link from 'next/link'
+
+import { HeatmapCalendar } from '@/components/heatmap-calendar'
+import { Main } from '@/components/main'
+import prisma from '@/lib/prisma'
+
+import { RecordActivityForm } from './record-activity-form'
+
+export default async function Page() {
+  const oneYearAgo = new Date()
+  oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1)
+  oneYearAgo.setHours(0, 0, 0, 0)
+
+  const logs = await prisma.activityLog.findMany({
+    where: { date: { gte: oneYearAgo } },
+    orderBy: { date: 'asc' },
+  })
+
+  const data = logs.map((log) => ({
+    date: log.date.toISOString().split('T')[0],
+    count: log.count,
+    note: log.note,
+  }))
+
+  return (
+    <Main className="max-w-4xl px-4">
+      <div className="w-full flex-1">
+        <Link className="inline-flex place-items-center gap-2" href="/">
+          <ArrowLeftIcon className="h-4 w-4" /> Home
+        </Link>
+      </div>
+
+      <div className="w-full space-y-8">
+        <h2 className="text-2xl font-bold">Activity</h2>
+        <RecordActivityForm />
+        <HeatmapCalendar data={data} />
+      </div>
+    </Main>
+  )
+}

--- a/app/activity/record-activity-form.tsx
+++ b/app/activity/record-activity-form.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useActionState } from 'react'
+
+import { recordActivity } from '@/actions/activity'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+export function RecordActivityForm() {
+  const [, formAction, isPending] = useActionState(
+    async (_prev: unknown, formData: FormData) => {
+      const note = (formData.get('note') as string) || ''
+      await recordActivity(note)
+    },
+    null,
+  )
+
+  return (
+    <form action={formAction} className="flex gap-2">
+      <Input
+        name="note"
+        placeholder="What did you work on?"
+        className="max-w-sm"
+        disabled={isPending}
+      />
+      <Button type="submit" disabled={isPending}>
+        {isPending ? 'Recording...' : 'Record Activity'}
+      </Button>
+    </form>
+  )
+}

--- a/app/activity/record-activity-form.tsx
+++ b/app/activity/record-activity-form.tsx
@@ -1,22 +1,24 @@
 'use client'
 
-import { useActionState } from 'react'
+import { useActionState, useRef } from 'react'
 
 import { recordActivity } from '@/actions/activity'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 
 export function RecordActivityForm() {
+  const formRef = useRef<HTMLFormElement>(null)
   const [, formAction, isPending] = useActionState(
     async (_prev: unknown, formData: FormData) => {
       const note = (formData.get('note') as string) || ''
       await recordActivity(note)
+      formRef.current?.reset()
     },
     null,
   )
 
   return (
-    <form action={formAction} className="flex gap-2">
+    <form ref={formRef} action={formAction} className="flex gap-2">
       <Input
         name="note"
         placeholder="What did you work on?"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { Toaster } from 'sonner'
 
 import { Footer } from '@/components/footer'
 import { Header } from '@/components/header'
+import { TooltipProvider } from '@/components/ui/tooltip'
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -31,10 +32,12 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} flex min-h-screen flex-col items-center bg-zinc-50 font-sans antialiased`}
       >
-        <Header />
-        {children}
-        <Footer />
-        <Toaster />
+        <TooltipProvider>
+          <Header />
+          {children}
+          <Footer />
+          <Toaster />
+        </TooltipProvider>
       </body>
     </html>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,6 +26,9 @@ export default async function Home() {
         <Button asChild variant="outline">
           <Link href="/react-flow-2">react-flow-2</Link>
         </Button>
+        <Button asChild variant="outline">
+          <Link href="/activity">activity</Link>
+        </Button>
       </Grid>
     </Main>
   )

--- a/components/heatmap-calendar.tsx
+++ b/components/heatmap-calendar.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef } from 'react'
 
+import { toLocalDateString } from '@/lib/date'
 import {
   Tooltip,
   TooltipContent,
@@ -81,7 +82,7 @@ function buildCalendarGrid(data: ActivityDay[]) {
 
   while (current <= today) {
     const day = current.getDay()
-    const dateStr = current.toISOString().split('T')[0]
+    const dateStr = toLocalDateString(current)
     const entry = dataMap.get(dateStr)
 
     cells.push({
@@ -123,7 +124,7 @@ function computeStreaks(data: ActivityDay[]) {
 
   let currentStreak = 0
   const cursor = new Date(today)
-  while (activeDates.has(cursor.toISOString().split('T')[0])) {
+  while (activeDates.has(toLocalDateString(cursor))) {
     currentStreak++
     cursor.setDate(cursor.getDate() - 1)
   }

--- a/components/heatmap-calendar.tsx
+++ b/components/heatmap-calendar.tsx
@@ -1,0 +1,273 @@
+'use client'
+
+import { useEffect, useMemo, useRef } from 'react'
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
+export type ActivityDay = {
+  date: string
+  count: number
+  note: string
+}
+
+type Props = {
+  data: ActivityDay[]
+}
+
+const CELL_SIZE = 13
+const CELL_GAP = 2
+const CELL_STEP = CELL_SIZE + CELL_GAP
+const WEEKS = 53
+const DAYS_IN_WEEK = 7
+const MONTH_LABEL_HEIGHT = 20
+const DAY_LABEL_WIDTH = 32
+
+const COLOR_FILLS = [
+  '#ebedf0',
+  '#9be9a8',
+  '#40c463',
+  '#30a14e',
+  '#216e39',
+] as const
+
+const DAY_LABELS = ['', 'Mon', '', 'Wed', '', 'Fri', ''] as const
+const MONTH_NAMES = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+] as const
+
+function getFillColor(count: number): string {
+  if (count === 0) return COLOR_FILLS[0]
+  if (count === 1) return COLOR_FILLS[1]
+  if (count <= 3) return COLOR_FILLS[2]
+  if (count <= 6) return COLOR_FILLS[3]
+  return COLOR_FILLS[4]
+}
+
+function buildCalendarGrid(data: ActivityDay[]) {
+  const dataMap = new Map(data.map((d) => [d.date, d]))
+
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  const startDay = new Date(today)
+  startDay.setDate(today.getDate() - today.getDay() - (WEEKS - 1) * 7)
+
+  const cells: {
+    date: Date
+    dateStr: string
+    count: number
+    note: string
+    week: number
+    day: number
+  }[] = []
+
+  const current = new Date(startDay)
+  let week = 0
+
+  while (current <= today) {
+    const day = current.getDay()
+    const dateStr = current.toISOString().split('T')[0]
+    const entry = dataMap.get(dateStr)
+
+    cells.push({
+      date: new Date(current),
+      dateStr,
+      count: entry?.count ?? 0,
+      note: entry?.note ?? '',
+      week,
+      day,
+    })
+
+    current.setDate(current.getDate() + 1)
+    if (current.getDay() === 0) week++
+  }
+
+  const totalWeeks = week + 1
+
+  const monthLabels: { label: string; week: number }[] = []
+  let lastMonth = -1
+  for (const cell of cells) {
+    const month = cell.date.getMonth()
+    if (month !== lastMonth && cell.day === 0) {
+      monthLabels.push({ label: MONTH_NAMES[month], week: cell.week })
+      lastMonth = month
+    }
+  }
+
+  return { cells, monthLabels, totalWeeks }
+}
+
+function computeStreaks(data: ActivityDay[]) {
+  const activeDates = new Set(
+    data.filter((d) => d.count > 0).map((d) => d.date),
+  )
+  const totalDays = activeDates.size
+
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  let currentStreak = 0
+  const cursor = new Date(today)
+  while (activeDates.has(cursor.toISOString().split('T')[0])) {
+    currentStreak++
+    cursor.setDate(cursor.getDate() - 1)
+  }
+
+  let longestStreak = 0
+  let streak = 0
+  const sorted = [...activeDates].sort()
+  for (let i = 0; i < sorted.length; i++) {
+    if (i === 0) {
+      streak = 1
+    } else {
+      const prev = new Date(sorted[i - 1])
+      const curr = new Date(sorted[i])
+      const diffMs = curr.getTime() - prev.getTime()
+      const ONE_DAY_MS = 86_400_000
+      streak = diffMs === ONE_DAY_MS ? streak + 1 : 1
+    }
+    longestStreak = Math.max(longestStreak, streak)
+  }
+
+  return { totalDays, currentStreak, longestStreak }
+}
+
+export function HeatmapCalendar({ data }: Props) {
+  const { cells, monthLabels, totalWeeks } = useMemo(
+    () => buildCalendarGrid(data),
+    [data],
+  )
+  const stats = useMemo(() => computeStreaks(data), [data])
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollLeft = scrollRef.current.scrollWidth
+    }
+  }, [])
+
+  const svgWidth = DAY_LABEL_WIDTH + totalWeeks * CELL_STEP
+  const svgHeight = MONTH_LABEL_HEIGHT + DAYS_IN_WEEK * CELL_STEP
+
+  return (
+    <div className="w-full space-y-4">
+      <div ref={scrollRef} className="overflow-x-auto">
+        <svg
+          width={svgWidth}
+          height={svgHeight}
+          className="font-sans"
+          role="img"
+          aria-label="Activity heatmap calendar"
+        >
+          {monthLabels.map((m) => (
+            <text
+              key={`${m.label}-${m.week}`}
+              x={DAY_LABEL_WIDTH + m.week * CELL_STEP}
+              y={14}
+              className="fill-muted-foreground text-[10px]"
+            >
+              {m.label}
+            </text>
+          ))}
+
+          {DAY_LABELS.map((label, i) =>
+            label ? (
+              <text
+                key={i}
+                x={0}
+                y={MONTH_LABEL_HEIGHT + i * CELL_STEP + CELL_SIZE - 2}
+                className="fill-muted-foreground text-[10px]"
+              >
+                {label}
+              </text>
+            ) : null,
+          )}
+
+          {cells.map((cell) => {
+            const x = DAY_LABEL_WIDTH + cell.week * CELL_STEP
+            const y = MONTH_LABEL_HEIGHT + cell.day * CELL_STEP
+            const fillColor = getFillColor(cell.count)
+            const tooltipText =
+              cell.count > 0
+                ? `${cell.dateStr}: ${cell.count} activit${cell.count === 1 ? 'y' : 'ies'}${cell.note ? ` — ${cell.note}` : ''}`
+                : `${cell.dateStr}: No activity`
+
+            return (
+              <Tooltip key={cell.dateStr}>
+                <TooltipTrigger asChild>
+                  <rect
+                    x={x}
+                    y={y}
+                    width={CELL_SIZE}
+                    height={CELL_SIZE}
+                    rx={2}
+                    fill={fillColor}
+                    stroke="rgba(27,31,35,0.06)"
+                    strokeWidth={1}
+                    style={{ cursor: 'pointer' }}
+                  />
+                </TooltipTrigger>
+                <TooltipContent side="top" className="text-xs">
+                  {tooltipText}
+                </TooltipContent>
+              </Tooltip>
+            )
+          })}
+        </svg>
+      </div>
+
+      <div className="text-muted-foreground flex items-center gap-2 text-xs">
+        <span>Less</span>
+        {COLOR_FILLS.map((color, i) => (
+          <svg key={i} width={CELL_SIZE} height={CELL_SIZE}>
+            <rect
+              width={CELL_SIZE}
+              height={CELL_SIZE}
+              rx={2}
+              fill={color}
+              stroke="rgba(27,31,35,0.06)"
+              strokeWidth={1}
+            />
+          </svg>
+        ))}
+        <span>More</span>
+      </div>
+
+      <div className="text-muted-foreground flex gap-6 text-sm">
+        <div>
+          Total:{' '}
+          <span className="text-foreground font-semibold">
+            {stats.totalDays} days
+          </span>
+        </div>
+        <div>
+          Longest Streak:{' '}
+          <span className="text-foreground font-semibold">
+            {stats.longestStreak}d
+          </span>
+        </div>
+        <div>
+          Current Streak:{' '}
+          <span className="text-foreground font-semibold">
+            {stats.currentStreak}d
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        'border-input selection:bg-primary selection:text-primary-foreground file:text-foreground placeholder:text-muted-foreground dark:bg-input/30 h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+        'aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import * as React from 'react'
+import { Tooltip as TooltipPrimitive } from 'radix-ui'
+
+import { cn } from '@/lib/utils'
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          'animate-in bg-foreground text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -1,0 +1,10 @@
+/**
+ * Format a Date as YYYY-MM-DD using the local timezone.
+ * Avoids the UTC shift caused by Date.toISOString().
+ */
+export function toLocalDateString(date: Date): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}

--- a/prisma/migrations/20260407103707_add_activity_log/migration.sql
+++ b/prisma/migrations/20260407103707_add_activity_log/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "ActivityLog" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "date" DATETIME NOT NULL,
+    "count" INTEGER NOT NULL DEFAULT 1,
+    "note" TEXT NOT NULL DEFAULT '',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ActivityLog_date_key" ON "ActivityLog"("date");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,3 +17,12 @@ model GuestNote {
   message   String
   createdAt DateTime @default(now())
 }
+
+/// Daily activity log for the heatmap calendar
+model ActivityLog {
+  id        Int      @id @default(autoincrement())
+  date      DateTime @unique
+  count     Int      @default(1)
+  note      String   @default("")
+  createdAt DateTime @default(now())
+}


### PR DESCRIPTION
## Summary

- Add a GitHub-style activity heatmap calendar at `/activity` that visualizes daily coding activity over the past year
- Implement `recordActivity` server action with Prisma upsert to track daily activity counts with optional notes
- Build `HeatmapCalendar` SVG component with GitHub's exact color scheme (`#9be9a8` → `#216e39`), hover tooltips, auto-scroll to current date, and streak statistics (total days, longest streak, current streak)

## Changes

| File | Description |
|------|-------------|
| `prisma/schema.prisma` | Add `ActivityLog` model with unique date, count, note |
| `prisma/migrations/…` | SQLite migration for `ActivityLog` table |
| `actions/activity.ts` | Server action: upsert today's activity, revalidate path |
| `app/activity/page.tsx` | Server component: fetch logs, render form + heatmap |
| `app/activity/record-activity-form.tsx` | Client form with `useActionState` for recording |
| `components/heatmap-calendar.tsx` | SVG heatmap grid, tooltip, legend, streak stats |
| `components/ui/input.tsx` | shadcn/ui Input component |
| `components/ui/tooltip.tsx` | shadcn/ui Tooltip component |
| `app/layout.tsx` | Wrap app in `TooltipProvider` |
| `app/page.tsx` | Add `/activity` link button to home |

## Test plan

- [ ] Navigate to `/activity` and verify the heatmap grid renders with month/day labels
- [ ] Click "Record Activity" and confirm the cell for today turns green
- [ ] Hover over cells to verify tooltip shows date and activity count
- [ ] Verify streak statistics update correctly after recording activity
- [ ] Check the legend displays the correct green gradient (Less → More)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity tracking page to record daily activity with optional notes
  * Interactive heatmap calendar showing one year of activity with color intensity, tooltips, and streak stats
  * Inline form to record activity with in-progress state and UI feedback
  * Home page navigation link to the activity tracker
  * App-wide tooltip provider for consistent tooltip behavior

* **Chores**
  * Database migration and date utility added to persist per-day activity logs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->